### PR TITLE
False boolean value and required constraint error

### DIFF
--- a/test.js
+++ b/test.js
@@ -15,7 +15,8 @@ var object = {
 		street: 'Haussmann 40'
 	},
 	title: 'Magesty',
-	digit: '1'
+	digit: '1',
+	registered: false
 }
 
 var rules = {
@@ -45,7 +46,10 @@ var rules = {
 		function ( value ) {
 			return value === 'Sir'
 		}
-	]
+	],
+	registered: {
+		required: true
+	}
 }
 
 /*

--- a/vindication.js
+++ b/vindication.js
@@ -17,7 +17,7 @@ var regexes = {
 
 var Vindication = {
 	requiredFn: function ( object, cvalue ) {
-		return !cvalue || object || _.isNumber(object)
+		return !cvalue || object || _.isNumber(object) || _.isBoolean(object)
 	},
 	minlengthFn: function ( object, cvalue ) {
 		return object && object.length >= cvalue


### PR DESCRIPTION
This issue is best illustrated with a quick and dirty example:

~~~~JavaScript
const obj = { prop: false }
const constraint = {
  prop: {
    required: true
  }
}
~~~~

Previously, validating `obj` resulted in an error, which is wrong, because `prop` is not missing. This PR fixes this behavior.